### PR TITLE
Add compile driver entrypoint and tests

### DIFF
--- a/src/diag/diagnostics.zig
+++ b/src/diag/diagnostics.zig
@@ -51,11 +51,11 @@ pub const Diagnostics = struct {
     /// Emit diagnostics to stderr. The current implementation prints byte offsets;
     /// a richer renderer can be added when line mapping is implemented.
     pub fn emitAll(self: *Diagnostics, source_map_ref: *source_map.SourceMap) !void {
-        var writer = std.io.getStdErr().writer();
         for (self.entries.items) |entry| {
             const file = source_map_ref.getFile(entry.primary_span.file_id);
             const path = if (file) |f| f.path else "<unknown>";
-            try writer.print("{s}: {s}:{d}-{d}: {s}\n", .{
+            var line_buffer: [256]u8 = undefined;
+            const line = try std.fmt.bufPrint(&line_buffer, "{s}: {s}:{d}-{d}: {s}\n", .{
                 switch (entry.severity) {
                     .err => "error",
                     .warning => "warning",
@@ -65,6 +65,7 @@ pub const Diagnostics = struct {
                 entry.primary_span.end,
                 entry.message,
             });
+            try std.fs.File.stderr().writeAll(line);
         }
     }
 };

--- a/src/driver.zig
+++ b/src/driver.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const diag = @import("diag/diagnostics.zig");
+const source_map = @import("diag/source_map.zig");
+const lexer = @import("frontend/lexer.zig");
+
+pub const CompileStatus = enum {
+    success,
+    errors,
+};
+
+pub const CompileResult = struct {
+    diagnostics: diag.Diagnostics,
+    source_map: source_map.SourceMap,
+    status: CompileStatus,
+
+    pub fn deinit(self: *CompileResult) void {
+        self.diagnostics.deinit();
+        self.source_map.deinit();
+    }
+};
+
+pub const CompileOptions = struct {
+    allocator: std.mem.Allocator,
+    input_path: []const u8,
+    emit_diagnostics: bool = true,
+    exit_on_error: bool = true,
+    source_override: ?[]const u8 = null,
+};
+
+pub fn compileFile(options: CompileOptions) !CompileResult {
+    var sm = source_map.SourceMap.init(options.allocator);
+    var diagnostics = diag.Diagnostics.init(options.allocator);
+
+    const contents = options.source_override orelse try std.fs.cwd().readFileAlloc(options.allocator, options.input_path, std.math.maxInt(usize));
+    defer if (options.source_override == null) options.allocator.free(contents);
+
+    const file_id = try sm.addFile(options.input_path, contents);
+
+    const tokens = try lexer.lex(options.allocator, file_id, contents, &diagnostics);
+    defer options.allocator.free(tokens);
+
+    // TODO: Frontend parsing to AST per Architecture.md.
+    // TODO: Lowering to HIR and semantic analysis.
+    // TODO: MIR construction and optimization passes.
+    // TODO: Backend code generation and emission.
+
+    const status: CompileStatus = if (diagnostics.hasErrors()) .errors else .success;
+
+    if (status == .errors and options.emit_diagnostics) {
+        try diagnostics.emitAll(&sm);
+    }
+
+    if (status == .errors and options.exit_on_error) {
+        diagnostics.deinit();
+        sm.deinit();
+        std.process.exit(1);
+    }
+
+    return .{ .diagnostics = diagnostics, .source_map = sm, .status = status };
+}
+
+test "compileFile succeeds on tokenizable source" {
+    const allocator = std.testing.allocator;
+    var result = try compileFile(.{
+        .allocator = allocator,
+        .input_path = "test.rs",
+        .emit_diagnostics = false,
+        .exit_on_error = false,
+        .source_override = "fn main() {}",
+    });
+    defer result.deinit();
+
+    try std.testing.expectEqual(CompileStatus.success, result.status);
+    try std.testing.expect(!result.diagnostics.hasErrors());
+}
+
+test "compileFile records diagnostics on lexer errors" {
+    const allocator = std.testing.allocator;
+    var result = try compileFile(.{
+        .allocator = allocator,
+        .input_path = "test.rs",
+        .emit_diagnostics = false,
+        .exit_on_error = false,
+        .source_override = "\"unterminated",
+    });
+    defer result.deinit();
+
+    try std.testing.expectEqual(CompileStatus.errors, result.status);
+    try std.testing.expect(result.diagnostics.hasErrors());
+}


### PR DESCRIPTION
## Summary
- add a compile driver that loads files, builds diagnostics/source maps, and runs lexing with TODO hooks for later stages
- refactor the CLI entrypoint to construct compile options and delegate to the driver
- add driver tests that cover successful tokenization and diagnostic propagation

## Testing
- zig test src/driver.zig
- zig test src/main.zig


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261c3c78a88325bdfdf6490a10ad63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal compiler pipeline restructured for improved organization and maintainability.
  * Diagnostic output handling optimized with buffered line construction; existing behavior maintained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->