### PR TITLE
Add AST definitions and parser integration

### DIFF
--- a/src/frontend/ast.zig
+++ b/src/frontend/ast.zig
@@ -1,0 +1,388 @@
+const source_map = @import("../diag/source_map.zig");
+const Span = source_map.Span;
+
+/// Top-level crate containing all parsed items.
+pub const Crate = struct {
+    items: []Item,
+};
+
+pub const Identifier = struct {
+    name: []const u8,
+    span: Span,
+};
+
+pub const Item = struct {
+    tag: Tag,
+    span: Span,
+    data: union(Tag) {
+        Fn: FnItem,
+        Struct: StructItem,
+        Impl: ImplItem,
+        TypeAlias: TypeAliasItem,
+        Empty: void,
+    },
+
+    pub const Tag = enum {
+        Fn,
+        Struct,
+        Impl,
+        TypeAlias,
+        Empty,
+    };
+};
+
+pub const FnItem = struct {
+    name: Identifier,
+    generics: []Identifier,
+    params: []Param,
+    return_type: ?Type,
+    body: Block,
+    span: Span,
+};
+
+pub const StructItem = struct {
+    name: Identifier,
+    generics: []Identifier,
+    fields: []Field,
+    span: Span,
+};
+
+pub const ImplItem = struct {
+    generics: []Identifier,
+    target: Type,
+    methods: []FnItem,
+    span: Span,
+};
+
+pub const TypeAliasItem = struct {
+    name: Identifier,
+    generics: []Identifier,
+    aliased_type: Type,
+    span: Span,
+};
+
+pub const Field = struct {
+    name: Identifier,
+    ty: Type,
+    span: Span,
+};
+
+pub const Param = struct {
+    pattern: Pattern,
+    ty: ?Type,
+    span: Span,
+    kind: Kind,
+
+    pub const Kind = enum {
+        Normal,
+        SelfValue,
+        SelfRef,
+        SelfRefMut,
+    };
+};
+
+pub const Pattern = struct {
+    tag: Tag,
+    span: Span,
+    data: union(Tag) {
+        Identifier: Identifier,
+        Wildcard: void,
+    },
+
+    pub const Tag = enum {
+        Identifier,
+        Wildcard,
+    };
+};
+
+pub const Type = struct {
+    tag: Tag,
+    span: Span,
+    data: union(Tag) {
+        Path: Path,
+        Primitive: Primitive,
+        Array: ArrayType,
+        Pointer: PointerType,
+        Reference: ReferenceType,
+        Function: FunctionType,
+    },
+
+    pub const Tag = enum {
+        Path,
+        Primitive,
+        Array,
+        Pointer,
+        Reference,
+        Function,
+    };
+};
+
+pub const Primitive = enum {
+    u32,
+    u64,
+    usize,
+    i32,
+    i64,
+    f32,
+    f64,
+    bool,
+    char,
+    str,
+    String,
+};
+
+pub const PointerType = struct {
+    is_mut: bool,
+    child: *Type,
+};
+
+pub const ReferenceType = struct {
+    is_mut: bool,
+    child: *Type,
+};
+
+pub const FunctionType = struct {
+    params: []Type,
+    return_type: *Type,
+};
+
+pub const ArrayType = struct {
+    element_type: *Type,
+    size_expr: *Expr,
+};
+
+pub const Path = struct {
+    segments: []Identifier,
+    generic_args: []Type,
+    span: Span,
+};
+
+pub const Expr = struct {
+    tag: Tag,
+    span: Span,
+    data: union(Tag) {
+        Literal: Literal,
+        Path: Path,
+        Block: Block,
+        If: IfExpr,
+        While: WhileExpr,
+        For: ForExpr,
+        Return: ReturnExpr,
+        Binary: BinaryExpr,
+        Unary: UnaryExpr,
+        Call: CallExpr,
+        Index: IndexExpr,
+        Field: FieldExpr,
+        MethodCall: MethodCallExpr,
+        Assignment: AssignmentExpr,
+        Cast: CastExpr,
+        Range: RangeExpr,
+        Lambda: LambdaExpr,
+        Array: ArrayExpr,
+        StructInit: StructInitExpr,
+        Paren: *Expr,
+    },
+
+    pub const Tag = enum {
+        Literal,
+        Path,
+        Block,
+        If,
+        While,
+        For,
+        Return,
+        Binary,
+        Unary,
+        Call,
+        Index,
+        Field,
+        MethodCall,
+        Assignment,
+        Cast,
+        Range,
+        Lambda,
+        Array,
+        StructInit,
+        Paren,
+    };
+};
+
+pub const Literal = struct {
+    kind: Kind,
+    lexeme: []const u8,
+
+    pub const Kind = enum {
+        Int,
+        Float,
+        Bool,
+        Char,
+        String,
+    };
+};
+
+pub const BinaryExpr = struct {
+    op: BinaryOp,
+    left: *Expr,
+    right: *Expr,
+};
+
+pub const BinaryOp = enum {
+    LogicalOr,
+    LogicalAnd,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+};
+
+pub const RangeExpr = struct {
+    inclusive: bool,
+    start: *Expr,
+    end: *Expr,
+};
+
+pub const UnaryExpr = struct {
+    op: UnaryOp,
+    expr: *Expr,
+};
+
+pub const UnaryOp = enum {
+    Not,
+    Neg,
+    Deref,
+    Ref,
+    RefMut,
+};
+
+pub const AssignmentExpr = struct {
+    target: *Expr,
+    op: AssignOp,
+    value: *Expr,
+};
+
+pub const AssignOp = enum {
+    Assign,
+    AddAssign,
+    SubAssign,
+    MulAssign,
+    DivAssign,
+};
+
+pub const CastExpr = struct {
+    expr: *Expr,
+    ty: *Type,
+};
+
+pub const IfExpr = struct {
+    condition: *Expr,
+    then_block: Block,
+    else_expr: ?*Expr,
+};
+
+pub const WhileExpr = struct {
+    condition: *Expr,
+    body: Block,
+};
+
+pub const ForExpr = struct {
+    pattern: Pattern,
+    iterator: *Expr,
+    body: Block,
+};
+
+pub const ReturnExpr = struct {
+    value: ?*Expr,
+};
+
+pub const CallExpr = struct {
+    callee: *Expr,
+    args: []Expr,
+};
+
+pub const IndexExpr = struct {
+    target: *Expr,
+    index: *Expr,
+};
+
+pub const FieldExpr = struct {
+    target: *Expr,
+    field: Identifier,
+};
+
+pub const MethodCallExpr = struct {
+    target: *Expr,
+    method: Identifier,
+    args: []Expr,
+};
+
+pub const LambdaExpr = struct {
+    params: []Param,
+    body: LambdaBody,
+};
+
+pub const LambdaBody = union(enum) {
+    Expr: *Expr,
+    Block: Block,
+};
+
+pub const ArrayExpr = struct {
+    elements: []Expr,
+};
+
+pub const StructInitExpr = struct {
+    path: Path,
+    fields: []StructInitField,
+};
+
+pub const StructInitField = struct {
+    name: Identifier,
+    value: Expr,
+};
+
+pub const Block = struct {
+    stmts: []Stmt,
+    result: ?*Expr,
+    span: Span,
+};
+
+pub const Stmt = struct {
+    tag: Tag,
+    span: Span,
+    data: union(Tag) {
+        Let: LetStmt,
+        Expr: ExprStmt,
+        While: WhileExpr,
+        If: IfExpr,
+        For: ForExpr,
+        Return: ReturnExpr,
+        Empty: void,
+    },
+
+    pub const Tag = enum {
+        Let,
+        Expr,
+        While,
+        If,
+        For,
+        Return,
+        Empty,
+    };
+};
+
+pub const LetStmt = struct {
+    mutable: bool,
+    pattern: Pattern,
+    ty: ?Type,
+    value: ?*Expr,
+};
+
+pub const ExprStmt = struct {
+    expr: Expr,
+};

--- a/src/frontend/parser.zig
+++ b/src/frontend/parser.zig
@@ -1,0 +1,859 @@
+const std = @import("std");
+const tokens = @import("tokens.zig");
+const ast = @import("ast.zig");
+const diag = @import("../diag/diagnostics.zig");
+const source_map = @import("../diag/source_map.zig");
+const Token = tokens.Token;
+const TokenKind = tokens.TokenKind;
+const Span = source_map.Span;
+
+pub fn parseCrate(arena: std.mem.Allocator, input: []const Token, diagnostics: *diag.Diagnostics) ast.Crate {
+    var parser = Parser{
+        .arena = arena,
+        .diagnostics = diagnostics,
+        .tokens = input,
+        .pos = 0,
+    };
+    return parser.parseCrate();
+}
+
+const Parser = struct {
+    arena: std.mem.Allocator,
+    diagnostics: *diag.Diagnostics,
+    tokens: []const Token,
+    pos: usize,
+
+    fn parseCrate(self: *Parser) ast.Crate {
+        var items = std.ArrayListUnmanaged(ast.Item){};
+
+        while (!self.isAtEnd()) {
+            if (self.peekKind() == .Semicolon) {
+                _ = self.advance();
+                continue;
+            }
+            if (self.parseItem()) |item| {
+                items.append(self.arena, item) catch {};
+            } else {
+                self.synchronize();
+            }
+        }
+
+        const owned = items.toOwnedSlice(self.arena) catch @panic("out of memory parsing crate");
+        return .{ .items = owned };
+    }
+
+    fn parseItem(self: *Parser) ?ast.Item {
+        const tok = self.peek();
+        switch (tok.kind) {
+            .KwFn => return self.parseFnItem(),
+            .KwStruct => return self.parseStructItem(),
+            .KwImpl => return self.parseImplItem(),
+            .KwType => return self.parseTypeAliasItem(),
+            .Semicolon => {
+                _ = self.advance();
+                return ast.Item{ .tag = .Empty, .span = tok.span, .data = .Empty };
+            },
+            else => {
+                self.reportError(tok.span, "expected item");
+                return null;
+            },
+        }
+    }
+
+    fn parseFnItem(self: *Parser) ?ast.Item {
+        const fn_token = self.expectConsume(.KwFn, "expected 'fn'") orelse return null;
+        const name_tok = self.expectConsume(.Identifier, "expected function name") orelse return null;
+        const name = self.makeIdent(name_tok);
+        const generics = self.parseGenericParams();
+        const params = self.parseParamList();
+        const ret_ty = if (self.match(.Arrow)) self.parseType() else null;
+        const body = self.parseBlock() orelse return null;
+        const span = Span{ .file_id = fn_token.span.file_id, .start = fn_token.span.start, .end = body.span.end };
+
+        return ast.Item{
+            .tag = .Fn,
+            .span = span,
+            .data = .{ .Fn = .{
+                .name = name,
+                .generics = generics,
+                .params = params,
+                .return_type = ret_ty,
+                .body = body,
+                .span = span,
+            } },
+        };
+    }
+
+    fn parseStructItem(self: *Parser) ?ast.Item {
+        const kw = self.expectConsume(.KwStruct, "expected 'struct'") orelse return null;
+        const name_tok = self.expectConsume(.Identifier, "expected struct name") orelse return null;
+        const name = self.makeIdent(name_tok);
+        const generics = self.parseGenericParams();
+        _ = self.expectConsume(.LBrace, "expected '{' after struct name") orelse return null;
+
+        var fields = std.ArrayListUnmanaged(ast.Field){};
+        while (!self.check(.RBrace) and !self.isAtEnd()) {
+            const field_name_tok = self.expectConsume(.Identifier, "expected field name") orelse break;
+            _ = self.expectConsume(.Colon, "expected ':' after field name") orelse break;
+            const ty = self.parseType() orelse break;
+            const field_span = Span{ .file_id = field_name_tok.span.file_id, .start = field_name_tok.span.start, .end = ty.span.end };
+            fields.append(self.arena, .{ .name = self.makeIdent(field_name_tok), .ty = ty, .span = field_span }) catch {};
+            if (self.match(.Comma)) {} else break;
+        }
+        const rbrace = self.expectConsume(.RBrace, "expected '}' to close struct") orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = rbrace.span.end };
+        return ast.Item{ .tag = .Struct, .span = span, .data = .{ .Struct = .{ .name = name, .generics = generics, .fields = fields.toOwnedSlice(self.arena) catch @panic("out of memory"), .span = span } } };
+    }
+
+    fn parseImplItem(self: *Parser) ?ast.Item {
+        const kw = self.expectConsume(.KwImpl, "expected 'impl'") orelse return null;
+        const generics = self.parseGenericParams();
+        const target_ty = self.parseType() orelse return null;
+        _ = self.expectConsume(.LBrace, "expected '{' in impl body") orelse return null;
+
+        var methods = std.ArrayListUnmanaged(ast.FnItem){};
+        while (!self.check(.RBrace) and !self.isAtEnd()) {
+            if (self.check(.KwFn)) {
+                if (self.parseFnItem()) |fn_item| {
+                    methods.append(self.arena, fn_item.data.Fn) catch {};
+                } else {
+                    self.synchronize();
+                }
+            } else if (self.match(.Semicolon)) {
+                continue;
+            } else {
+                self.reportError(self.peek().span, "expected function in impl");
+                self.synchronize();
+            }
+        }
+
+        const rbrace = self.expectConsume(.RBrace, "expected '}' to close impl") orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = rbrace.span.end };
+        return ast.Item{ .tag = .Impl, .span = span, .data = .{ .Impl = .{ .generics = generics, .target = target_ty, .methods = methods.toOwnedSlice(self.arena) catch @panic("out of memory"), .span = span } } };
+    }
+
+    fn parseTypeAliasItem(self: *Parser) ?ast.Item {
+        const kw = self.expectConsume(.KwType, "expected 'type'") orelse return null;
+        const name_tok = self.expectConsume(.Identifier, "expected type alias name") orelse return null;
+        const name = self.makeIdent(name_tok);
+        const generics = self.parseGenericParams();
+        _ = self.expectConsume(.Eq, "expected '=' in type alias") orelse return null;
+        const ty = self.parseType() orelse return null;
+        const semi = self.expectConsume(.Semicolon, "expected ';' after type alias") orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = semi.span.end };
+        return ast.Item{ .tag = .TypeAlias, .span = span, .data = .{ .TypeAlias = .{ .name = name, .generics = generics, .aliased_type = ty, .span = span } } };
+    }
+
+    fn parseGenericParams(self: *Parser) []ast.Identifier {
+        if (!self.match(.Lt)) return &[_]ast.Identifier{};
+        var params = std.ArrayListUnmanaged(ast.Identifier){};
+        while (!self.check(.Gt) and !self.isAtEnd()) {
+            const tok = self.expectConsume(.Identifier, "expected generic parameter") orelse break;
+            params.append(self.arena, self.makeIdent(tok)) catch {};
+            if (!self.match(.Comma)) break;
+        }
+        _ = self.expectConsume(.Gt, "expected '>' after generics") orelse {};
+        return params.toOwnedSlice(self.arena) catch @panic("out of memory");
+    }
+
+    fn parseParamList(self: *Parser) []ast.Param {
+        _ = self.expectConsume(.LParen, "expected '(' after function name") orelse return &[_]ast.Param{};
+        var params = std.ArrayListUnmanaged(ast.Param){};
+        if (!self.check(.RParen)) {
+            while (true) {
+                if (self.check(.KwSelf) or self.checkSelfRef()) {
+                    const param = self.parseSelfParam();
+                    params.append(self.arena, param) catch {};
+                } else {
+                    const pattern = self.parsePattern() orelse break;
+                    const ty = if (self.match(.Colon)) self.parseType() else null;
+                    const span_end = if (ty) |t| t.span.end else pattern.span.end;
+                    const param_span = Span{ .file_id = pattern.span.file_id, .start = pattern.span.start, .end = span_end };
+                    params.append(self.arena, .{ .pattern = pattern, .ty = ty, .span = param_span, .kind = .Normal }) catch {};
+                }
+                if (!self.match(.Comma)) break;
+            }
+        }
+        _ = self.expectConsume(.RParen, "expected ')' after parameters") orelse {};
+        return params.toOwnedSlice(self.arena) catch @panic("out of memory");
+    }
+
+    fn parseSelfParam(self: *Parser) ast.Param {
+        var span_start: usize = self.peek().span.start;
+        const amp = self.match(.Amp);
+        if (amp) span_start = self.previous().span.start;
+        const mut = self.match(.KwMut);
+        const self_tok = self.expectConsume(.KwSelf, "expected 'self'") orelse self.peek();
+        const span = Span{ .file_id = self_tok.span.file_id, .start = span_start, .end = self_tok.span.end };
+        const kind: ast.Param.Kind = if (amp and mut)
+            .SelfRefMut
+        else if (amp)
+            .SelfRef
+        else
+            .SelfValue;
+        return .{ .pattern = .{ .tag = .Identifier, .span = self_tok.span, .data = .{ .Identifier = self.makeIdent(self_tok) } }, .ty = null, .span = span, .kind = kind };
+    }
+
+    fn parsePattern(self: *Parser) ?ast.Pattern {
+        const tok = self.peek();
+        switch (tok.kind) {
+            .Identifier => {
+                _ = self.advance();
+                if (std.mem.eql(u8, tok.lexeme, "_")) {
+                    return ast.Pattern{ .tag = .Wildcard, .span = tok.span, .data = .Wildcard };
+                }
+                return ast.Pattern{ .tag = .Identifier, .span = tok.span, .data = .{ .Identifier = self.makeIdent(tok) } };
+            },
+            else => {
+                self.reportError(tok.span, "expected pattern");
+                return null;
+            },
+        }
+    }
+
+    fn parseType(self: *Parser) ?ast.Type {
+        const tok = self.peek();
+        switch (tok.kind) {
+            .Star => {
+                const star = self.advance();
+                const mut_tok = self.match(.KwMut);
+                const child = self.parseType() orelse return null;
+                const span = Span{ .file_id = star.span.file_id, .start = star.span.start, .end = child.span.end };
+                const node = ast.Type{ .tag = .Pointer, .span = span, .data = .{ .Pointer = .{ .is_mut = mut_tok, .child = self.copyType(child) } } };
+                return node;
+            },
+            .Amp => {
+                const amp = self.advance();
+                const mut_tok = self.match(.KwMut);
+                const child = self.parseType() orelse return null;
+                const span = Span{ .file_id = amp.span.file_id, .start = amp.span.start, .end = child.span.end };
+                const node = ast.Type{ .tag = .Reference, .span = span, .data = .{ .Reference = .{ .is_mut = mut_tok, .child = self.copyType(child) } } };
+                return node;
+            },
+            .KwFn => {
+                const start = self.advance();
+                _ = self.expectConsume(.LParen, "expected '(' after 'fn'") orelse return null;
+                var params = std.ArrayListUnmanaged(ast.Type){};
+                if (!self.check(.RParen)) {
+                    while (true) {
+                        const ty = self.parseType() orelse break;
+                        params.append(self.arena, ty) catch {};
+                        if (!self.match(.Comma)) break;
+                    }
+                }
+                _ = self.expectConsume(.RParen, "expected ')' in function type") orelse {};
+                _ = self.expectConsume(.Arrow, "expected '->' in function type") orelse return null;
+                const ret = self.parseType() orelse return null;
+                const span = Span{ .file_id = start.span.file_id, .start = start.span.start, .end = ret.span.end };
+                return ast.Type{ .tag = .Function, .span = span, .data = .{ .Function = .{ .params = params.toOwnedSlice(self.arena) catch @panic("out of memory"), .return_type = self.copyType(ret) } } };
+            },
+            .LBracket => {
+                const lbrack = self.advance();
+                const elem_ty = self.parseType() orelse return null;
+                _ = self.expectConsume(.Semicolon, "expected ';' in array type") orelse return null;
+                const size_expr = self.parseExpr() orelse return null;
+                const rbrack = self.expectConsume(.RBracket, "expected ']' in array type") orelse return null;
+                const span = Span{ .file_id = lbrack.span.file_id, .start = lbrack.span.start, .end = rbrack.span.end };
+                return ast.Type{ .tag = .Array, .span = span, .data = .{ .Array = .{ .element_type = self.copyType(elem_ty), .size_expr = size_expr } } };
+            },
+            else => {
+                if (self.parsePath()) |p| {
+                    const prim = primFromPath(p);
+                    if (prim) |pr| {
+                        return ast.Type{ .tag = .Primitive, .span = p.span, .data = .{ .Primitive = pr } };
+                    }
+                    return ast.Type{ .tag = .Path, .span = p.span, .data = .{ .Path = p } };
+                }
+                self.reportError(tok.span, "expected type");
+                return null;
+            },
+        }
+    }
+
+    fn primFromPath(path: ast.Path) ?ast.Primitive {
+        if (path.segments.len != 1) return null;
+        const name = path.segments[0].name;
+        return std.meta.stringToEnum(ast.Primitive, name);
+    }
+
+    fn parsePath(self: *Parser) ?ast.Path {
+        if (!self.check(.Identifier)) return null;
+        var segments = std.ArrayListUnmanaged(ast.Identifier){};
+        const first = self.advance();
+        segments.append(self.arena, self.makeIdent(first)) catch {};
+        while (self.match(.DoubleColon)) {
+            const seg_tok = self.expectConsume(.Identifier, "expected path segment") orelse break;
+            segments.append(self.arena, self.makeIdent(seg_tok)) catch {};
+        }
+
+        var args = std.ArrayListUnmanaged(ast.Type){};
+        if (self.match(.Lt)) {
+            while (!self.check(.Gt) and !self.isAtEnd()) {
+                const arg = self.parseType() orelse break;
+                args.append(self.arena, arg) catch {};
+                if (!self.match(.Comma)) break;
+            }
+            _ = self.expectConsume(.Gt, "expected '>' after generic arguments") orelse {};
+        }
+
+        const last_span = segments.items[segments.items.len - 1].span;
+        const end_pos: usize = if (args.items.len > 0) args.items[args.items.len - 1].span.end else last_span.end;
+        const span = Span{ .file_id = last_span.file_id, .start = first.span.start, .end = end_pos };
+        return .{ .segments = segments.toOwnedSlice(self.arena) catch @panic("out of memory"), .generic_args = args.toOwnedSlice(self.arena) catch @panic("out of memory"), .span = span };
+    }
+
+    fn parseBlock(self: *Parser) ?ast.Block {
+        const lbrace = self.expectConsume(.LBrace, "expected '{'") orelse return null;
+        var stmts = std.ArrayListUnmanaged(ast.Stmt){};
+        var result_expr: ?*ast.Expr = null;
+        while (!self.check(.RBrace) and !self.isAtEnd()) {
+            if (self.match(.Semicolon)) {
+                stmts.append(self.arena, .{ .tag = .Empty, .span = lbrace.span, .data = .Empty }) catch {};
+                continue;
+            }
+
+            if (self.check(.KwLet)) {
+                if (self.parseLetStmt()) |stmt| stmts.append(self.arena, stmt) catch {} else self.synchronize();
+                continue;
+            }
+            if (self.check(.KwWhile)) {
+                if (self.parseWhileStmt()) |stmt| stmts.append(self.arena, stmt) catch {} else self.synchronize();
+                continue;
+            }
+            if (self.check(.KwIf)) {
+                if (self.parseIfStmt()) |stmt| stmts.append(self.arena, stmt) catch {} else self.synchronize();
+                continue;
+            }
+            if (self.check(.KwFor)) {
+                if (self.parseForStmt()) |stmt| stmts.append(self.arena, stmt) catch {} else self.synchronize();
+                continue;
+            }
+            if (self.check(.KwReturn)) {
+                if (self.parseReturnStmt()) |stmt| stmts.append(self.arena, stmt) catch {} else self.synchronize();
+                continue;
+            }
+
+            if (self.isStartOfExpr()) {
+                if (self.parseExpr()) |expr| {
+                    if (self.match(.Semicolon)) {
+                        stmts.append(self.arena, .{ .tag = .Expr, .span = expr.span, .data = .{ .Expr = .{ .expr = expr.* } } }) catch {};
+                    } else {
+                        result_expr = expr;
+                        break;
+                    }
+                } else self.synchronize();
+            } else {
+                self.reportError(self.peek().span, "unexpected token in block");
+                self.synchronize();
+            }
+        }
+        const rbrace = self.expectConsume(.RBrace, "expected '}' to close block") orelse return null;
+        const span = Span{ .file_id = lbrace.span.file_id, .start = lbrace.span.start, .end = rbrace.span.end };
+        return ast.Block{ .stmts = stmts.toOwnedSlice(self.arena) catch @panic("out of memory"), .result = result_expr, .span = span };
+    }
+
+    fn parseLetStmt(self: *Parser) ?ast.Stmt {
+        const kw = self.expectConsume(.KwLet, "expected 'let'") orelse return null;
+        const is_mut = self.match(.KwMut);
+        const pattern = self.parsePattern() orelse return null;
+        var ty: ?ast.Type = null;
+        if (self.match(.Colon)) {
+            ty = self.parseType();
+        }
+        var value: ?*ast.Expr = null;
+        if (self.match(.Eq)) {
+            value = self.parseExpr();
+        }
+        const semi = self.expectConsume(.Semicolon, "expected ';' after let statement") orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = semi.span.end };
+        return ast.Stmt{ .tag = .Let, .span = span, .data = .{ .Let = .{ .mutable = is_mut, .pattern = pattern, .ty = ty, .value = value } } };
+    }
+
+    fn parseWhileStmt(self: *Parser) ?ast.Stmt {
+        const kw = self.expectConsume(.KwWhile, "expected 'while'") orelse return null;
+        const cond = self.parseExpr() orelse return null;
+        const body = self.parseBlock() orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = body.span.end };
+        return ast.Stmt{ .tag = .While, .span = span, .data = .{ .While = .{ .condition = cond, .body = body } } };
+    }
+
+    fn parseIfStmt(self: *Parser) ?ast.Stmt {
+        if (self.parseIfExpr()) |expr| {
+            return ast.Stmt{ .tag = .If, .span = expr.span, .data = .{ .If = expr.data.If } };
+        }
+        return null;
+    }
+
+    fn parseForStmt(self: *Parser) ?ast.Stmt {
+        const kw = self.expectConsume(.KwFor, "expected 'for'") orelse return null;
+        const pat = self.parsePattern() orelse return null;
+        _ = self.expectConsume(.KwIn, "expected 'in' after pattern") orelse return null;
+        const iter = self.parseExpr() orelse return null;
+        const body = self.parseBlock() orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = body.span.end };
+        return ast.Stmt{ .tag = .For, .span = span, .data = .{ .For = .{ .pattern = pat, .iterator = iter, .body = body } } };
+    }
+
+    fn parseReturnStmt(self: *Parser) ?ast.Stmt {
+        const kw = self.expectConsume(.KwReturn, "expected 'return'") orelse return null;
+        var value: ?*ast.Expr = null;
+        if (!self.check(.Semicolon)) {
+            value = self.parseExpr();
+        }
+        const semi = self.expectConsume(.Semicolon, "expected ';' after return") orelse return null;
+        const span = Span{ .file_id = kw.span.file_id, .start = kw.span.start, .end = semi.span.end };
+        return ast.Stmt{ .tag = .Return, .span = span, .data = .{ .Return = .{ .value = value } } };
+    }
+
+    fn parseExpr(self: *Parser) ?*ast.Expr {
+        return self.parseAssign();
+    }
+
+    fn parseAssign(self: *Parser) ?*ast.Expr {
+        const left = self.parseIfExpr() orelse return null;
+        if (self.match(.Eq) or self.match(.PlusEq) or self.match(.MinusEq) or self.match(.StarEq) or self.match(.SlashEq)) {
+            const op_token = self.previous();
+            const value = self.parseAssign() orelse return null;
+            const op = switch (op_token.kind) {
+                .Eq => ast.AssignOp.Assign,
+                .PlusEq => ast.AssignOp.AddAssign,
+                .MinusEq => ast.AssignOp.SubAssign,
+                .StarEq => ast.AssignOp.MulAssign,
+                .SlashEq => ast.AssignOp.DivAssign,
+                else => ast.AssignOp.Assign,
+            };
+            const span = Span{ .file_id = left.span.file_id, .start = left.span.start, .end = value.span.end };
+            return self.allocExpr(.{ .tag = .Assignment, .span = span, .data = .{ .Assignment = .{ .target = left, .op = op, .value = value } } });
+        }
+        return left;
+    }
+
+    fn parseIfExpr(self: *Parser) ?*ast.Expr {
+        if (!self.match(.KwIf)) {
+            return self.parseOr();
+        }
+        const if_tok = self.previous();
+        const cond = self.parseExpr() orelse return null;
+        const then_block = self.parseBlock() orelse return null;
+        var else_expr: ?*ast.Expr = null;
+        if (self.match(.KwElse)) {
+            if (self.check(.KwIf)) {
+                else_expr = self.parseIfExpr();
+            } else {
+                if (self.parseBlock()) |blk| {
+                    else_expr = self.allocExpr(.{ .tag = .Block, .span = blk.span, .data = .{ .Block = blk } });
+                }
+            }
+        }
+        const end_span = if (else_expr) |e| e.span.end else then_block.span.end;
+        const span = Span{ .file_id = if_tok.span.file_id, .start = if_tok.span.start, .end = end_span };
+        return self.allocExpr(.{ .tag = .If, .span = span, .data = .{ .If = .{ .condition = cond, .then_block = then_block, .else_expr = else_expr } } });
+    }
+
+    fn parseOr(self: *Parser) ?*ast.Expr {
+        var expr = self.parseAnd() orelse return null;
+        while (self.match(.DoublePipe)) {
+            const rhs = self.parseAnd() orelse break;
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Binary, .span = span, .data = .{ .Binary = .{ .op = .LogicalOr, .left = expr, .right = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseAnd(self: *Parser) ?*ast.Expr {
+        var expr = self.parseEq() orelse return null;
+        while (self.match(.DoubleAmp)) {
+            const rhs = self.parseEq() orelse break;
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Binary, .span = span, .data = .{ .Binary = .{ .op = .LogicalAnd, .left = expr, .right = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseEq(self: *Parser) ?*ast.Expr {
+        var expr = self.parseRel() orelse return null;
+        while (self.match(.DoubleEq) or self.match(.BangEq)) {
+            const op_tok = self.previous();
+            const rhs = self.parseRel() orelse break;
+            const op: ast.BinaryOp = if (op_tok.kind == .DoubleEq) .Eq else .Ne;
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Binary, .span = span, .data = .{ .Binary = .{ .op = op, .left = expr, .right = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseRel(self: *Parser) ?*ast.Expr {
+        var expr = self.parseRange() orelse return null;
+        while (self.match(.Lt) or self.match(.Le) or self.match(.Gt) or self.match(.Ge)) {
+            const op_tok = self.previous();
+            const rhs = self.parseRange() orelse break;
+            const op = switch (op_tok.kind) {
+                .Lt => ast.BinaryOp.Lt,
+                .Le => ast.BinaryOp.Le,
+                .Gt => ast.BinaryOp.Gt,
+                .Ge => ast.BinaryOp.Ge,
+                else => ast.BinaryOp.Lt,
+            };
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Binary, .span = span, .data = .{ .Binary = .{ .op = op, .left = expr, .right = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseRange(self: *Parser) ?*ast.Expr {
+        var expr = self.parseAdd() orelse return null;
+        while (self.match(.DotDot) or self.match(.DotDotEq)) {
+            const op_tok = self.previous();
+            const rhs = self.parseAdd() orelse break;
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Range, .span = span, .data = .{ .Range = .{ .inclusive = op_tok.kind == .DotDotEq, .start = expr, .end = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseAdd(self: *Parser) ?*ast.Expr {
+        var expr = self.parseMul() orelse return null;
+        while (self.match(.Plus) or self.match(.Minus)) {
+            const op_tok = self.previous();
+            const rhs = self.parseMul() orelse break;
+            const op = if (op_tok.kind == .Plus) ast.BinaryOp.Add else ast.BinaryOp.Sub;
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Binary, .span = span, .data = .{ .Binary = .{ .op = op, .left = expr, .right = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseMul(self: *Parser) ?*ast.Expr {
+        var expr = self.parseCast() orelse return null;
+        while (self.match(.Star) or self.match(.Slash) or self.match(.Percent)) {
+            const op_tok = self.previous();
+            const rhs = self.parseCast() orelse break;
+            const op = switch (op_tok.kind) {
+                .Star => ast.BinaryOp.Mul,
+                .Slash => ast.BinaryOp.Div,
+                .Percent => ast.BinaryOp.Mod,
+                else => ast.BinaryOp.Mul,
+            };
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rhs.span.end };
+            expr = self.allocExpr(.{ .tag = .Binary, .span = span, .data = .{ .Binary = .{ .op = op, .left = expr, .right = rhs } } });
+        }
+        return expr;
+    }
+
+    fn parseCast(self: *Parser) ?*ast.Expr {
+        var expr = self.parseUnary() orelse return null;
+        while (self.match(.KwAs)) {
+            const ty = self.parseType() orelse break;
+            const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = ty.span.end };
+            expr = self.allocExpr(.{ .tag = .Cast, .span = span, .data = .{ .Cast = .{ .expr = expr, .ty = self.copyType(ty) } } });
+        }
+        return expr;
+    }
+
+    fn parseUnary(self: *Parser) ?*ast.Expr {
+        if (self.match(.Bang) or self.match(.Minus) or self.match(.Star) or self.match(.Amp)) {
+            const op_tok = self.previous();
+            const mut_ref = op_tok.kind == .Amp and self.match(.KwMut);
+            const rhs = self.parseUnary() orelse return null;
+            const op = switch (op_tok.kind) {
+                .Bang => ast.UnaryOp.Not,
+                .Minus => ast.UnaryOp.Neg,
+                .Star => ast.UnaryOp.Deref,
+                .Amp => if (mut_ref) ast.UnaryOp.RefMut else ast.UnaryOp.Ref,
+                else => ast.UnaryOp.Not,
+            };
+            const span = Span{ .file_id = op_tok.span.file_id, .start = op_tok.span.start, .end = rhs.span.end };
+            return self.allocExpr(.{ .tag = .Unary, .span = span, .data = .{ .Unary = .{ .op = op, .expr = rhs } } });
+        }
+        return self.parsePostfix();
+    }
+
+    fn parsePostfix(self: *Parser) ?*ast.Expr {
+        var expr = self.parsePrimary() orelse return null;
+        while (true) {
+            if (self.match(.LParen)) {
+                var args = std.ArrayListUnmanaged(ast.Expr){};
+                if (!self.check(.RParen)) {
+                    while (true) {
+                        const arg = self.parseExpr() orelse break;
+                        args.append(self.arena, arg.*) catch {};
+                        if (!self.match(.Comma)) break;
+                    }
+                }
+                const rparen = self.expectConsume(.RParen, "expected ')' after call") orelse return null;
+                const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rparen.span.end };
+                expr = self.allocExpr(.{ .tag = .Call, .span = span, .data = .{ .Call = .{ .callee = expr, .args = args.toOwnedSlice(self.arena) catch @panic("out of memory") } } });
+                continue;
+            }
+            if (self.match(.LBracket)) {
+                const index_expr = self.parseExpr() orelse return null;
+                const rbrack = self.expectConsume(.RBracket, "expected ']' after index") orelse return null;
+                const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = rbrack.span.end };
+                expr = self.allocExpr(.{ .tag = .Index, .span = span, .data = .{ .Index = .{ .target = expr, .index = index_expr } } });
+                continue;
+            }
+            if (self.match(.Dot)) {
+                const field_tok = self.expectConsume(.Identifier, "expected field name") orelse return null;
+                const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = field_tok.span.end };
+                expr = self.allocExpr(.{ .tag = .Field, .span = span, .data = .{ .Field = .{ .target = expr, .field = self.makeIdent(field_tok) } } });
+                continue;
+            }
+            if (self.match(.Bang)) {
+                // Macro call: treat as call with no args for now.
+                const span = Span{ .file_id = expr.span.file_id, .start = expr.span.start, .end = self.previous().span.end };
+                expr = self.allocExpr(.{ .tag = .Call, .span = span, .data = .{ .Call = .{ .callee = expr, .args = &[_]ast.Expr{} } } });
+                continue;
+            }
+            break;
+        }
+        return expr;
+    }
+
+    fn parsePrimary(self: *Parser) ?*ast.Expr {
+        const tok = self.peek();
+        switch (tok.kind) {
+            .IntLit, .FloatLit, .BoolLit, .CharLit, .StringLit => {
+                _ = self.advance();
+                const lit_kind: ast.Literal.Kind = switch (tok.kind) {
+                    .IntLit => .Int,
+                    .FloatLit => .Float,
+                    .BoolLit => .Bool,
+                    .CharLit => .Char,
+                    .StringLit => .String,
+                    else => .Int,
+                };
+                const expr = ast.Expr{ .tag = .Literal, .span = tok.span, .data = .{ .Literal = .{ .kind = lit_kind, .lexeme = self.dup(tok.lexeme) } } };
+                return self.copyExpr(expr);
+            },
+            .Identifier => {
+                if (self.parsePath()) |p| {
+                    return self.allocExpr(.{ .tag = .Path, .span = p.span, .data = .{ .Path = p } });
+                }
+                return null;
+            },
+            .LParen => {
+                _ = self.advance();
+                const expr = self.parseExpr() orelse return null;
+                const rparen = self.expectConsume(.RParen, "expected ')' after expression") orelse return expr;
+                const span = Span{ .file_id = tok.span.file_id, .start = tok.span.start, .end = rparen.span.end };
+                return self.allocExpr(.{ .tag = .Paren, .span = span, .data = .{ .Paren = expr } });
+            },
+            .LBrace => {
+                if (self.parseBlock()) |blk| {
+                    return self.allocExpr(.{ .tag = .Block, .span = blk.span, .data = .{ .Block = blk } });
+                }
+                return null;
+            },
+            .LBracket => {
+                const lbrack = self.advance();
+                var elements = std.ArrayListUnmanaged(ast.Expr){};
+                if (!self.check(.RBracket)) {
+                    while (true) {
+                        const elem = self.parseExpr() orelse break;
+                        elements.append(self.arena, elem.*) catch {};
+                        if (!self.match(.Comma)) break;
+                    }
+                }
+                const rbrack = self.expectConsume(.RBracket, "expected ']' after array literal") orelse return null;
+                const span = Span{ .file_id = lbrack.span.file_id, .start = lbrack.span.start, .end = rbrack.span.end };
+                return self.allocExpr(.{ .tag = .Array, .span = span, .data = .{ .Array = .{ .elements = elements.toOwnedSlice(self.arena) catch @panic("out of memory") } } });
+            },
+            .Pipe => {
+                _ = self.advance();
+                var params = std.ArrayListUnmanaged(ast.Param){};
+                if (!self.check(.Pipe)) {
+                    while (true) {
+                        const pat = self.parsePattern() orelse break;
+                        const ty = if (self.match(.Colon)) self.parseType() else null;
+                        const span_end = if (ty) |t| t.span.end else pat.span.end;
+                        const param_span = Span{ .file_id = pat.span.file_id, .start = pat.span.start, .end = span_end };
+                        params.append(self.arena, .{ .pattern = pat, .ty = ty, .span = param_span, .kind = .Normal }) catch {};
+                        if (!self.match(.Comma)) break;
+                    }
+                }
+                _ = self.expectConsume(.Pipe, "expected '|' to close lambda parameters") orelse return null;
+                if (self.check(.LBrace)) {
+                    const blk = self.parseBlock() orelse return null;
+                    const span = Span{ .file_id = tok.span.file_id, .start = tok.span.start, .end = blk.span.end };
+                    return self.allocExpr(.{ .tag = .Lambda, .span = span, .data = .{ .Lambda = .{ .params = params.toOwnedSlice(self.arena) catch @panic("out of memory"), .body = .{ .Block = blk } } } });
+                }
+                if (self.parseExpr()) |body_expr| {
+                    const span = Span{ .file_id = tok.span.file_id, .start = tok.span.start, .end = body_expr.span.end };
+                    return self.allocExpr(.{ .tag = .Lambda, .span = span, .data = .{ .Lambda = .{ .params = params.toOwnedSlice(self.arena) catch @panic("out of memory"), .body = .{ .Expr = body_expr } } } });
+                }
+                return null;
+            },
+            else => {
+                self.reportError(tok.span, "expected expression");
+                return null;
+            },
+        }
+    }
+
+    fn isStartOfExpr(self: *Parser) bool {
+        return switch (self.peekKind()) {
+            .LParen, .LBrace, .LBracket, .Identifier, .IntLit, .FloatLit, .BoolLit, .CharLit, .StringLit, .KwIf, .KwWhile, .KwFor, .KwReturn, .Bang, .Minus, .Star, .Amp, .Pipe => true,
+            else => false,
+        };
+    }
+
+    fn expectConsume(self: *Parser, kind: TokenKind, message: []const u8) ?Token {
+        if (self.check(kind)) return self.advance();
+        self.reportError(self.peek().span, message);
+        return null;
+    }
+
+    fn reportError(self: *Parser, span: Span, message: []const u8) void {
+        self.diagnostics.reportError(span, message);
+    }
+
+    fn synchronize(self: *Parser) void {
+        while (!self.isAtEnd()) {
+            if (self.previous().kind == .Semicolon) return;
+            switch (self.peekKind()) {
+                .KwFn, .KwStruct, .KwImpl, .KwType, .KwLet, .KwWhile, .KwFor, .KwIf, .KwReturn => return,
+                .RBrace => return,
+                else => {},
+            }
+            _ = self.advance();
+        }
+    }
+
+    fn allocExpr(self: *Parser, expr: ast.Expr) *ast.Expr {
+        const ptr = self.arena.create(ast.Expr) catch @panic("out of memory");
+        ptr.* = expr;
+        return ptr;
+    }
+
+    fn copyExpr(self: *Parser, expr: ast.Expr) *ast.Expr {
+        const ptr = self.arena.create(ast.Expr) catch @panic("out of memory");
+        ptr.* = expr;
+        return ptr;
+    }
+
+    fn copyType(self: *Parser, ty: ast.Type) *ast.Type {
+        const ptr = self.arena.create(ast.Type) catch @panic("out of memory");
+        ptr.* = ty;
+        return ptr;
+    }
+
+    fn makeIdent(self: *Parser, tok: Token) ast.Identifier {
+        return .{ .name = self.dup(tok.lexeme), .span = tok.span };
+    }
+
+    fn dup(self: *Parser, slice: []const u8) []const u8 {
+        return self.arena.dupe(u8, slice) catch slice;
+    }
+
+    fn match(self: *Parser, kind: TokenKind) bool {
+        if (!self.check(kind)) return false;
+        _ = self.advance();
+        return true;
+    }
+
+    fn check(self: *Parser, kind: TokenKind) bool {
+        if (self.isAtEnd()) return false;
+        return self.peekKind() == kind;
+    }
+
+    fn checkSelfRef(self: *Parser) bool {
+        if (!self.check(.Amp)) return false;
+        if (self.pos + 1 >= self.tokens.len) return false;
+        const next = self.tokens[self.pos + 1];
+        return next.kind == .KwSelf or (next.kind == .KwMut and self.pos + 2 < self.tokens.len and self.tokens[self.pos + 2].kind == .KwSelf);
+    }
+
+    fn advance(self: *Parser) Token {
+        if (!self.isAtEnd()) self.pos += 1;
+        return self.tokens[self.pos - 1];
+    }
+
+    fn isAtEnd(self: *Parser) bool {
+        return self.pos >= self.tokens.len;
+    }
+
+    fn peek(self: *Parser) Token {
+        if (self.isAtEnd()) return self.tokens[self.tokens.len - 1];
+        return self.tokens[self.pos];
+    }
+
+    fn peekKind(self: *Parser) TokenKind {
+        return self.peek().kind;
+    }
+
+    fn previous(self: *Parser) Token {
+        return self.tokens[self.pos - 1];
+    }
+};
+
+// --------------------------
+// Tests
+// --------------------------
+
+const lexer = @import("lexer.zig");
+
+const ParseFixture = struct {
+    arena: std.heap.ArenaAllocator,
+    diagnostics: diag.Diagnostics,
+    crate: ast.Crate,
+};
+
+fn parseSource(src: []const u8) !ParseFixture {
+    const allocator = std.testing.allocator;
+    var diagnostics = diag.Diagnostics.init(allocator);
+    const file_id: source_map.FileId = 0;
+    const toks = try lexer.lex(allocator, file_id, src, &diagnostics);
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    const crate = parseCrate(arena.allocator(), toks, &diagnostics);
+    allocator.free(toks);
+    return .{ .arena = arena, .diagnostics = diagnostics, .crate = crate };
+}
+
+fn expectNoErrors(src: []const u8) !ParseFixture {
+    var fixture = try parseSource(src);
+    try std.testing.expect(!fixture.diagnostics.hasErrors());
+    return fixture;
+}
+
+test "parse simple fn" {
+    var fixture = try expectNoErrors("fn main() {}");
+    defer {
+        fixture.diagnostics.deinit();
+        fixture.arena.deinit();
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), fixture.crate.items.len);
+    try std.testing.expectEqual(ast.Item.Tag.Fn, fixture.crate.items[0].tag);
+}
+
+test "parse let binding in block" {
+    var fixture = try expectNoErrors("fn main() { let x: i32 = 1; }");
+    defer {
+        fixture.diagnostics.deinit();
+        fixture.arena.deinit();
+    }
+    const fn_item = fixture.crate.items[0].data.Fn;
+    try std.testing.expectEqual(@as(usize, 1), fn_item.body.stmts.len);
+    try std.testing.expectEqual(ast.Stmt.Tag.Let, fn_item.body.stmts[0].tag);
+}
+
+test "parse binary expressions" {
+    var fixture = try expectNoErrors("fn main() { let x = 1 + 2 * 3; }");
+    defer {
+        fixture.diagnostics.deinit();
+        fixture.arena.deinit();
+    }
+    const stmt = fixture.crate.items[0].data.Fn.body.stmts[0].data.Let;
+    try std.testing.expect(stmt.value != null);
+    const expr = stmt.value.?;
+    try std.testing.expect(expr.data.Binary.op == ast.BinaryOp.Add);
+}
+
+test "report error on missing semicolon" {
+    var fixture = try parseSource("fn main() { let x = 1 }");
+    defer {
+        fixture.diagnostics.deinit();
+        fixture.arena.deinit();
+    }
+    try std.testing.expect(fixture.diagnostics.hasErrors());
+}

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+// Import parser module to run its internal tests with module root anchored at src/.
+test "parser module" {
+    _ = @import("frontend/parser.zig");
+}


### PR DESCRIPTION
## Summary
- add AST definitions covering items, expressions, patterns, and types with span metadata
- implement a recursive-descent parser with diagnostic reporting and recovery
- integrate parsing into the driver and add parser and driver tests

## Testing
- zig test src/parser_tests.zig
- zig test src/driver.zig

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926205f28fc8325a81520bd2cc2a4ac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frontend parsing support for the complete language grammar including functions, structs, implementations, type aliases, generics, and comprehensive expression handling (literals, operators, control flow, lambdas).
  * Integrated parsed abstract syntax trees into the compilation pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->