### PR TITLE
Add compile options for emission and optimization

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,9 @@ pub fn main() !void {
 
     var visualize_tokens = false;
     var visualize_ast = false;
+    var opt_level: driver.OptLevel = .basic;
+    var emit: driver.Emit = .assembly;
+    var output_path: ?[]u8 = null;
     var path: ?[]const u8 = null;
 
     while (args.next()) |arg| {
@@ -18,6 +21,29 @@ pub fn main() !void {
             visualize_tokens = true;
         } else if (std.mem.eql(u8, arg, "--print-ast")) {
             visualize_ast = true;
+        } else if (std.mem.startsWith(u8, arg, "--opt=")) {
+            const value = arg["--opt=".len..];
+            const parsed = parseOptLevel(value) orelse {
+                printUsage();
+                return;
+            };
+            opt_level = parsed;
+        } else if (std.mem.startsWith(u8, arg, "--emit=")) {
+            const value = arg["--emit=".len..];
+            const parsed = parseEmit(value) orelse {
+                printUsage();
+                return;
+            };
+            emit = parsed;
+        } else if (std.mem.eql(u8, arg, "-o")) {
+            const out_path = args.next() orelse {
+                printUsage();
+                return;
+            };
+            if (output_path) |existing| {
+                allocator.free(existing);
+            }
+            output_path = try allocator.dupe(u8, out_path);
         } else if (std.mem.startsWith(u8, arg, "-")) {
             printUsage();
             return;
@@ -34,9 +60,15 @@ pub fn main() !void {
         return;
     }
 
+    const final_output_path = output_path orelse try defaultOutputPath(allocator, path.?, emit);
+    defer allocator.free(final_output_path);
+
     var result = try driver.compileFile(.{
         .allocator = allocator,
         .input_path = path.?,
+        .output_path = final_output_path,
+        .opt_level = opt_level,
+        .emit = emit,
         .emit_diagnostics = true,
         .exit_on_error = true,
         .visualize_tokens = visualize_tokens,
@@ -55,5 +87,34 @@ test "Run all tests" {
 }
 
 fn printUsage() void {
-    std.debug.print("usage: {s} [--print-tokens] [--print-ast] <file>\n", .{"rust-compiler"});
+    std.debug.print(
+        "usage: {s} [--print-tokens] [--print-ast] [--opt=none|basic] [--emit=asm|obj] [-o <path>] <file>\n",
+        .{"rust-compiler"},
+    );
+}
+
+fn parseOptLevel(value: []const u8) ?driver.OptLevel {
+    if (std.mem.eql(u8, value, "none")) return .none;
+    if (std.mem.eql(u8, value, "basic")) return .basic;
+    return null;
+}
+
+fn parseEmit(value: []const u8) ?driver.Emit {
+    if (std.mem.eql(u8, value, "asm")) return .assembly;
+    if (std.mem.eql(u8, value, "obj")) return .object;
+    return null;
+}
+
+fn defaultOutputPath(allocator: std.mem.Allocator, input_path: []const u8, emit: driver.Emit) ![]u8 {
+    const dir = std.fs.path.dirname(input_path) orelse ".";
+    const base = std.fs.path.basename(input_path);
+    const ext = std.fs.path.extension(base);
+    const stem = base[0 .. base.len - ext.len];
+    const suffix = switch (emit) {
+        .assembly => ".s",
+        .object => ".o",
+    };
+    const filename = try std.fmt.allocPrint(allocator, "{s}{s}", .{ stem, suffix });
+    defer allocator.free(filename);
+    return std.fs.path.join(allocator, &.{ dir, filename });
 }


### PR DESCRIPTION
## Summary
- add opt-level and emit enums to compile options and wire CLI flags for selecting them
- write backend artifacts to a chosen output path with default assembly emission
- add driver tests covering optimization gating and artifact emission

## Testing
- zig test src/driver.zig

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926766729b8832582b6f0c6d6d752fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--opt` flag to configure optimization levels: none or basic
  * Added `--emit` flag to select output format: assembly
  * Added `-o` flag to specify custom output file path

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->