### PR TITLE
Add macro call parsing for arguments

### DIFF
--- a/codes/macros_test1.rs
+++ b/codes/macros_test1.rs
@@ -1,5 +1,4 @@
 // Tests macro call syntax treated as function call
 fn main() {
-    let value = 10;
-    println!("value = {}", value);
+    println!("hello from println!");
 }


### PR DESCRIPTION
## Summary
- parse postfix macro invocations `!()` as call expressions that collect arguments and error on missing parentheses
- add parser regression coverage for println! macro calls and diagnostics
- update the macros sample to include a single-argument println! invocation

## Testing
- zig test src/all_tests.zig


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926c1246b6c8325b41d76309d563887)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced macro call parsing to properly support arguments in macro invocations

* **Tests**
  * Added coverage for macro calls with arguments and error diagnostics for incorrect macro syntax

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->