### PR TITLE
Add println end-to-end integration test

### DIFF
--- a/codes/hello_println.rs
+++ b/codes/hello_println.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello");
+}

--- a/src/all_tests.zig
+++ b/src/all_tests.zig
@@ -19,4 +19,5 @@ test "all modules" {
     _ = @import("mir/passes/passes.zig");
     _ = @import("parser_tests.zig");
     _ = @import("main.zig");
+    _ = @import("e2e_println.zig");
 }

--- a/src/e2e_println.zig
+++ b/src/e2e_println.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const driver = @import("driver.zig");
+
+// End-to-end integration test that compiles a sample program,
+// links the generated assembly into a binary, executes it, and
+// asserts the output matches the println! expectation.
+test "println end-to-end emits hello" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const asm_path = try std.fs.path.join(allocator, &.{ tmp_path, "hello.s" });
+    defer allocator.free(asm_path);
+
+    const bin_path = try std.fs.path.join(allocator, &.{ tmp_path, "hello.bin" });
+    defer allocator.free(bin_path);
+
+    var result = try driver.compileFile(.{
+        .allocator = allocator,
+        .input_path = "codes/hello_println.rs",
+        .output_path = asm_path,
+        .opt_level = .basic,
+        .emit = .assembly,
+        .emit_diagnostics = false,
+        .exit_on_error = false,
+    });
+    defer result.deinit();
+
+    try std.testing.expectEqual(driver.CompileStatus.success, result.status);
+
+    const cc_result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "zig", "cc", "-o", bin_path, asm_path },
+    });
+    defer {
+        allocator.free(cc_result.stdout);
+        allocator.free(cc_result.stderr);
+    }
+
+    switch (cc_result.term) {
+        .Exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.TestExpectedEqual,
+    }
+
+    const run_result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{bin_path},
+    });
+    defer {
+        allocator.free(run_result.stdout);
+        allocator.free(run_result.stderr);
+    }
+
+    switch (run_result.term) {
+        .Exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.TestExpectedEqual,
+    }
+
+    try std.testing.expectEqualStrings("hello\n", run_result.stdout);
+}


### PR DESCRIPTION
## Summary
- add a codes fixture for a minimal println! program and an integration test that compiles and runs it
- wire the new end-to-end test into the aggregated Zig test runner

## Testing
- zig build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d2507e5c8325bb4b472fbc0ab994)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example program demonstrating printing output to standard output.

* **Tests**
  * Added end-to-end test verifying the example program compiles correctly and produces the expected output with proper exit validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->