### PR TITLE
Add println! lowering and backend string support

### DIFF
--- a/src/backend/x86_64/machine.zig
+++ b/src/backend/x86_64/machine.zig
@@ -36,6 +36,7 @@ pub const MOperand = union(enum) {
     Phys: PhysReg,
     Imm: i64,
     Mem: MemRef,
+    Label: []const u8,
 };
 
 pub const BinOpcode = enum { add, sub, imul, idiv, imod, and_, or_, xor_ };
@@ -60,6 +61,8 @@ pub const MachineBlock = struct {
     insts: []InstKind,
 };
 
+pub const StringLiteral = struct { name: []const u8, value: []const u8 };
+
 pub const MachineFn = struct {
     name: []const u8,
     blocks: []MachineBlock,
@@ -77,11 +80,17 @@ pub const MachineFn = struct {
 pub const MachineCrate = struct {
     allocator: std.mem.Allocator,
     fns: []MachineFn,
+    strings: []StringLiteral,
 
     pub fn deinit(self: *MachineCrate) void {
         for (self.fns) |*f| {
             f.deinit(self.allocator);
         }
         self.allocator.free(self.fns);
+        for (self.strings) |lit| {
+            self.allocator.free(lit.name);
+            self.allocator.free(lit.value);
+        }
+        self.allocator.free(self.strings);
     }
 };

--- a/src/hir/name_res.zig
+++ b/src/hir/name_res.zig
@@ -124,6 +124,12 @@ fn resolveExpr(
                 return;
             }
 
+            if (std.mem.eql(u8, name, "println")) {
+                // Treat println! as a built-in macro and defer lowering to later stages
+                // without emitting an unresolved-identifier error here.
+                return;
+            }
+
             const message = std.fmt.allocPrint(
                 diagnostics.allocator,
                 "unresolved identifier `{s}`",

--- a/src/mir/mir.zig
+++ b/src/mir/mir.zig
@@ -84,11 +84,13 @@ pub const MirFn = struct {
     locals: []MirType,
     ret_ty: ?MirType,
     blocks: []Block,
+    is_extern: bool = false,
 };
 
 pub const MirCrate = struct {
     arena: std.heap.ArenaAllocator,
     fns: std.ArrayListUnmanaged(MirFn),
+    builtin_printf: ?u32 = null,
 
     pub fn init(backing_allocator: std.mem.Allocator) MirCrate {
         return .{ .arena = std.heap.ArenaAllocator.init(backing_allocator), .fns = .{} };


### PR DESCRIPTION
## Summary
- treat `println!` macro invocations as built-ins and validate format strings during type checking
- lower `println!` calls into `printf` calls with synthesized C-format strings and an injected external symbol
- extend x86_64 backend to carry string literals, emit Intel-syntax assembly, and support varargs call setup

## Testing
- zig test src/all_tests.zig

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d56404ec8325bee3b79dadf3e9c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type checking and format validation to the println! macro with support for multiple argument types.
  * Enhanced assembly generation with string literal emission and updated stack frame handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->