### PR TITLE
Lower println! macros to printf calls

### DIFF
--- a/src/backend/x86_64/isel.zig
+++ b/src/backend/x86_64/isel.zig
@@ -306,6 +306,8 @@ fn lowerTerm(
             if (maybe_op) |op| {
                 const lowered = lowerSimpleOperand(ctx, op, vreg_count) catch |err| return err;
                 try insts.append(ctx.allocator, .{ .Mov = .{ .dst = .{ .Phys = .rax }, .src = lowered } });
+            } else {
+                try insts.append(ctx.allocator, .{ .Mov = .{ .dst = .{ .Phys = .rax }, .src = .{ .Imm = 0 } } });
             }
             try insts.append(ctx.allocator, .{ .Ret = null });
         },
@@ -347,6 +349,7 @@ fn resolveCallTarget(target: mir.Operand, mir_crate: *const mir.MirCrate, diagno
             }
             break :blk mir_crate.fns.items[id].name;
         },
+        .Symbol => |name| name,
         else => {
             diagnostics.reportError(zero_span, "only direct function calls are supported in x86_64 lowering");
             return error.Unsupported;

--- a/src/mir/mir.zig
+++ b/src/mir/mir.zig
@@ -30,6 +30,7 @@ pub const Operand = union(enum) {
     ImmBool: bool,
     ImmChar: u21,
     ImmString: []const u8,
+    Symbol: []const u8,
     Global: u32,
 };
 


### PR DESCRIPTION
## Summary
- detect println! macro calls during MIR lowering, synthesize printf format strings from literal placeholders, and forward arguments directly
- register builtin println for name resolution/type checking and default call results to unit-like values
- emit assembly in GAS Intel syntax with position-independent string loads and zero return values for functions without explicit operands

## Testing
- zig test src/all_tests.zig

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926da18ffbc8325913b90dcd9ce93d6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added println builtin macro for simplified output functionality
  * Enhanced x86_64 assembly generation with improved syntax formatting and stack alignment

* **Improvements**
  * Expanded compiler support for additional call target types
  * Refined return value handling in generated code

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->